### PR TITLE
feat(eslint-config): ✨ Add support for `react`, `preact` and `next`

### DIFF
--- a/.changeset/light-apricots-push.md
+++ b/.changeset/light-apricots-push.md
@@ -1,0 +1,8 @@
+---
+"@terminal-nerds/eslint-config": minor
+---
+
+✨ Add better support for [next.js] with [config-next]
+
+[next.js]: https://nextjs.org/
+[config-next]: https://nextjs.org/docs/basic-features/eslint#eslint-config

--- a/.changeset/rude-carrots-reply.md
+++ b/.changeset/rude-carrots-reply.md
@@ -1,0 +1,15 @@
+---
+"@terminal-nerds/eslint-config": minor
+---
+
+✨ Add better support for [react] or [preact] with:
+
+-   [plugin jsx-a11y]
+-   [plugin react]
+-   [plugin react-hook]
+
+[react]: https://reactjs.org/
+[preact]: https://preactjs.com/
+[plugin jsx-a11y]: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
+[plugin react]: https://github.com/yannickcr/eslint-plugin-react
+[plugin react-hooks]: https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -92,8 +92,11 @@ _conditionally_.
 
 | Configurations           | Version                                 | Loading condition(s)     |
 | ------------------------ | --------------------------------------- | ------------------------ |
+| [eslint-config-next]     | ![eslint-config-next version badge]     | `next` as dependency     |
 | [eslint-config-prettier] | ![eslint-config-prettier version badge] | `prettier` as dependency |
 
+[eslint-config-next]: https://nextjs.org/docs/basic-features/eslint#eslint-config
+[eslint-config-next version badge]: https://img.shields.io/npm/v/eslint-config-next?logo=npm&style=flat-square
 [eslint-config-prettier]: https://github.com/prettier/eslint-config-prettier
 [eslint-config-prettier version badge]: https://img.shields.io/npm/v/eslint-config-prettier?logo=npm&style=flat-square
 
@@ -107,7 +110,10 @@ _conditionally_.
 | [eslint-plugin-import]                | ![eslint-plugin-import version badge]                | -                                                                            |
 | [eslint-plugin-json-schema-validator] | ![eslint-plugin-json-schema-validator version badge] | -                                                                            |
 | [eslint-plugin-jsonc]                 | ![eslint-plugin-jsonc version badge]                 | -                                                                            |
+| [eslint-plugin-jsx-a11y]              | ![eslint-plugin-jsx-a11y version badge]              | `react` or `preact` as dependency                                            |
 | [eslint-plugin-node]                  | ![eslint-plugin-node version badge]                  | -                                                                            |
+| [eslint-plugin-react]                 | ![eslint-plugin-react version badge]                 | `react` or `preact` as dependency                                            |
+| [eslint-plugin-react-hooks]           | ![eslint-plugin-react-hooks version badge]           | `react` or `preact` as dependency                                            |
 | [eslint-plugin-regexp]                | ![eslint-plugin-regexp version badge]                | -                                                                            |
 | [eslint-plugin-sonarjs]               | ![eslint-plugin-sonarjs version badge]               | -                                                                            |
 | [eslint-plugin-storybook]             | ![eslint-plugin-storybook version badge]             | `sb` as dependency                                                           |
@@ -127,8 +133,14 @@ _conditionally_.
 [eslint-plugin-json-schema-validator version badge]: https://img.shields.io/npm/v/eslint-plugin-json-schema-validator?logo=npm&style=flat-square
 [eslint-plugin-jsonc]: https://github.com/ota-meshi/eslint-plugin-jsonc
 [eslint-plugin-jsonc version badge]: https://img.shields.io/npm/v/eslint-plugin-jsonc?logo=npm&style=flat-square
+[eslint-plugin-jsx-a11y]: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
+[eslint-plugin-jsx-a11y version badge]: https://img.shields.io/npm/v/eslint-plugin-jsx-a11y?logo=npm&style=flat-square
 [eslint-plugin-node]: https://github.com/mysticatea/eslint-plugin-node
 [eslint-plugin-node version badge]: https://img.shields.io/npm/v/eslint-plugin-node?logo=npm&style=flat-square
+[eslint-plugin-react]: https://github.com/yannickcr/eslint-plugin-react
+[eslint-plugin-react version badge]: https://img.shields.io/npm/v/eslint-plugin-react?logo=npm&style=flat-square
+[eslint-plugin-react-hooks]: https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
+[eslint-plugin-react-hooks version badge]: https://img.shields.io/npm/v/eslint-plugin-react-hooks?logo=npm&style=flat-square
 [eslint-plugin-regexp]: https://github.com/ota-meshi/eslint-plugin-regexp
 [eslint-plugin-regexp version badge]: https://img.shields.io/npm/v/eslint-plugin-regexp?logo=npm&style=flat-square
 [eslint-plugin-sonarjs]: https://github.com/SonarSource/eslint-plugin-sonarjs

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -56,6 +56,7 @@
 		"eslint-plugin-jsonc": "^2.1.0",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-react": "^7.29.4",
+		"eslint-plugin-react-hooks": "^4.3.0",
 		"eslint-plugin-regexp": "^1.5.1",
 		"eslint-plugin-sonarjs": "^0.12.0",
 		"eslint-plugin-storybook": "^0.5.6",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -47,6 +47,7 @@
 		"@rushstack/eslint-patch": "^1.1.0",
 		"@typescript-eslint/eslint-plugin": "^5.10.2",
 		"@typescript-eslint/parser": "^5.10.2",
+		"eslint-config-next": "^12.1.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-define-config": "^1.2.4",
 		"eslint-plugin-compat": "^4.0.2",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -55,6 +55,7 @@
 		"eslint-plugin-json-schema-validator": "^2.1.48",
 		"eslint-plugin-jsonc": "^2.1.0",
 		"eslint-plugin-node": "^11.1.0",
+		"eslint-plugin-react": "^7.29.4",
 		"eslint-plugin-regexp": "^1.5.1",
 		"eslint-plugin-sonarjs": "^0.12.0",
 		"eslint-plugin-storybook": "^0.5.6",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -54,6 +54,7 @@
 		"eslint-plugin-import": "^2.25.4",
 		"eslint-plugin-json-schema-validator": "^2.1.48",
 		"eslint-plugin-jsonc": "^2.1.0",
+		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-react": "^7.29.4",
 		"eslint-plugin-react-hooks": "^4.3.0",

--- a/packages/eslint/source/configs/next.ts
+++ b/packages/eslint/source/configs/next.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "eslint-define-config";
+
+// https://github.com/prettier/eslint-config-prettier
+const config = defineConfig({
+	extends: ["next/core-web-vitals"],
+});
+
+export default config;

--- a/packages/eslint/source/index.ts
+++ b/packages/eslint/source/index.ts
@@ -12,6 +12,7 @@ import pluginDiff from "./plugins/diff.js";
 import pluginImport from "./plugins/import.js";
 import pluginJSONC from "./plugins/jsonc.js";
 import pluginJSONSchemaValidator from "./plugins/json-schema-validator.js";
+import pluginJSXA11y from "./plugins/jsx-a11y.js";
 import pluginNode from "./plugins/node.js";
 import pluginSonarJS from "./plugins/sonarjs.js";
 import pluginReact from "./plugins/react.js";
@@ -35,6 +36,7 @@ const mergedConfig = createMergedConfig([
 	pluginImport,
 	pluginJSONC,
 	pluginJSONSchemaValidator,
+	(hasModule("react") || hasModule("preact")) && pluginJSXA11y,
 	pluginNode,
 	(hasModule("react") || hasModule("preact")) && pluginReact,
 	(hasModule("react") || hasModule("preact")) && pluginReactHooks,

--- a/packages/eslint/source/index.ts
+++ b/packages/eslint/source/index.ts
@@ -24,6 +24,7 @@ import pluginTypeScript from "./plugins/typescript.js";
 import pluginUnicorn from "./plugins/unicorn.js";
 import pluginYML from "./plugins/yml.js";
 
+import configNext from "./configs/next.js";
 import configPrettier from "./configs/prettier.js";
 
 const mergedConfig = createMergedConfig([
@@ -50,6 +51,7 @@ const mergedConfig = createMergedConfig([
 
 	// Configs
 	// NOTE: Must come as last!
+	hasModule("next") && configNext,
 	hasModule("prettier") && configPrettier,
 ]);
 

--- a/packages/eslint/source/index.ts
+++ b/packages/eslint/source/index.ts
@@ -14,6 +14,8 @@ import pluginJSONC from "./plugins/jsonc.js";
 import pluginJSONSchemaValidator from "./plugins/json-schema-validator.js";
 import pluginNode from "./plugins/node.js";
 import pluginSonarJS from "./plugins/sonarjs.js";
+import pluginReact from "./plugins/react.js";
+import pluginRegexp from "./plugins/regexp.js";
 import pluginStorybook from "./plugins/storybook.js";
 import pluginSvelte3 from "./plugins/svelte3.js";
 import pluginTypeScript from "./plugins/typescript.js";
@@ -33,6 +35,8 @@ const mergedConfig = createMergedConfig([
 	pluginJSONC,
 	pluginJSONSchemaValidator,
 	pluginNode,
+	(hasModule("react") || hasModule("preact")) && pluginReact,
+	pluginRegexp,
 	pluginSonarJS,
 	hasModule("sb") && pluginStorybook,
 	hasModule("svelte") && pluginSvelte3,

--- a/packages/eslint/source/index.ts
+++ b/packages/eslint/source/index.ts
@@ -15,6 +15,7 @@ import pluginJSONSchemaValidator from "./plugins/json-schema-validator.js";
 import pluginNode from "./plugins/node.js";
 import pluginSonarJS from "./plugins/sonarjs.js";
 import pluginReact from "./plugins/react.js";
+import pluginReactHooks from "./plugins/react-hooks.js";
 import pluginRegexp from "./plugins/regexp.js";
 import pluginStorybook from "./plugins/storybook.js";
 import pluginSvelte3 from "./plugins/svelte3.js";
@@ -36,6 +37,7 @@ const mergedConfig = createMergedConfig([
 	pluginJSONSchemaValidator,
 	pluginNode,
 	(hasModule("react") || hasModule("preact")) && pluginReact,
+	(hasModule("react") || hasModule("preact")) && pluginReactHooks,
 	pluginRegexp,
 	pluginSonarJS,
 	hasModule("sb") && pluginStorybook,

--- a/packages/eslint/source/plugins/jsx-a11y.ts
+++ b/packages/eslint/source/plugins/jsx-a11y.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "eslint-define-config";
+
+// https://github.com/mysticatea/eslint-plugin-node
+const config = defineConfig({
+	extends: ["plugin:jsx-a11y/recommended"],
+});
+
+export default config;

--- a/packages/eslint/source/plugins/react-hooks.ts
+++ b/packages/eslint/source/plugins/react-hooks.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "eslint-define-config";
+
+// https://github.com/mysticatea/eslint-plugin-node
+const config = defineConfig({
+	extends: ["plugin:react-hooks/recommended"],
+});
+
+export default config;

--- a/packages/eslint/source/plugins/react.ts
+++ b/packages/eslint/source/plugins/react.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "eslint-define-config";
+
+// https://github.com/mysticatea/eslint-plugin-node
+const config = defineConfig({
+	extends: ["plugin:react/recommended"],
+	rules: {
+		// RATIONALE:
+		// `<></>` can be confusing, is better to use `<Fragment></Fragment>`
+		// for readability
+		"react/jsx-fragments": ["warn", "element"],
+	},
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
       '@workspace/helpers': workspace:*
+      eslint-config-next: ^12.1.0
       eslint-config-prettier: ^8.3.0
       eslint-define-config: ^1.2.4
       eslint-plugin-compat: ^4.0.2
@@ -81,7 +82,10 @@ importers:
       eslint-plugin-import: ^2.25.4
       eslint-plugin-json-schema-validator: ^2.1.48
       eslint-plugin-jsonc: ^2.1.0
+      eslint-plugin-jsx-a11y: ^6.5.1
       eslint-plugin-node: ^11.1.0
+      eslint-plugin-react: ^7.29.4
+      eslint-plugin-react-hooks: ^4.3.0
       eslint-plugin-regexp: ^1.5.1
       eslint-plugin-sonarjs: ^0.12.0
       eslint-plugin-storybook: ^0.5.6
@@ -96,6 +100,7 @@ importers:
       '@rushstack/eslint-patch': 1.1.0
       '@typescript-eslint/eslint-plugin': 5.12.1_081c03d76d837c78345e63a04e571e7f
       '@typescript-eslint/parser': 5.12.1_eslint@8.11.0+typescript@4.6.2
+      eslint-config-next: 12.1.0_eslint@8.11.0+typescript@4.6.2
       eslint-config-prettier: 8.4.0_eslint@8.11.0
       eslint-define-config: 1.2.5
       eslint-plugin-compat: 4.0.2_eslint@8.11.0
@@ -103,7 +108,10 @@ importers:
       eslint-plugin-import: 2.25.4_eslint@8.11.0
       eslint-plugin-json-schema-validator: 2.3.6_eslint@8.11.0
       eslint-plugin-jsonc: 2.2.1_eslint@8.11.0
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@8.11.0
       eslint-plugin-node: 11.1.0_eslint@8.11.0
+      eslint-plugin-react: 7.29.4_eslint@8.11.0
+      eslint-plugin-react-hooks: 4.3.0_eslint@8.11.0
       eslint-plugin-regexp: 1.5.1_eslint@8.11.0
       eslint-plugin-sonarjs: 0.12.0_eslint@8.11.0
       eslint-plugin-storybook: 0.5.7_eslint@8.11.0+typescript@4.6.2
@@ -282,12 +290,19 @@ packages:
     hasBin: true
     dev: true
 
+  /@babel/runtime-corejs3/7.17.7:
+    resolution: {integrity: sha512-TvliGJjhxis5m7xIMvlXH/xG8Oa/LK0SCUCyfKD6nLi42n5fB4WibDJ0g9trmmBB6hwpMNx+Lzbxy9/4gpMaVw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.21.1
+      regenerator-runtime: 0.13.9
+    dev: false
+
   /@babel/runtime/7.17.2:
     resolution: {integrity: sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
-    dev: true
 
   /@babel/template/7.16.7:
     resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
@@ -588,6 +603,12 @@ packages:
 
   /@mdn/browser-compat-data/4.1.9:
     resolution: {integrity: sha512-MGIACLLfhkuJ4rV5JPIOFNLJN+JWgYmV83NMBfx8EvRma+kcEAFivVgHHuEPJtdCba5zRpMx/cIGrXfVyGN56g==}
+    dev: false
+
+  /@next/eslint-plugin-next/12.1.0:
+    resolution: {integrity: sha512-WFiyvSM2G5cQmh32t/SiQuJ+I2O+FHVlK/RFw5b1565O2kEM/36EXncjt88Pa+X5oSc+1SS+tWxowWJd1lqI+g==}
+    dependencies:
+      glob: 7.1.7
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:
@@ -1040,6 +1061,14 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /aria-query/4.2.2:
+    resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      '@babel/runtime': 7.17.2
+      '@babel/runtime-corejs3': 7.17.7
+    dev: false
+
   /array-differ/3.0.0:
     resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
     engines: {node: '>=8'}
@@ -1068,6 +1097,15 @@ packages:
       es-abstract: 1.19.1
     dev: false
 
+  /array.prototype.flatmap/1.2.5:
+    resolution: {integrity: sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
+      es-abstract: 1.19.1
+    dev: false
+
   /arrify/1.0.1:
     resolution: {integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=}
     engines: {node: '>=0.10.0'}
@@ -1083,6 +1121,10 @@ packages:
       '@mdn/browser-compat-data': 3.3.14
     dev: false
 
+  /ast-types-flow/0.0.7:
+    resolution: {integrity: sha1-9wtzXGvKGlycItmCw+Oef+ujva0=}
+    dev: false
+
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -1096,6 +1138,15 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /axe-core/4.4.1:
+    resolution: {integrity: sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /axobject-query/2.2.0:
+    resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
+    dev: false
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1503,6 +1554,11 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
+  /core-js-pure/3.21.1:
+    resolution: {integrity: sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==}
+    requiresBuild: true
+    dev: false
+
   /core-js/3.21.1:
     resolution: {integrity: sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==}
     requiresBuild: true
@@ -1587,6 +1643,10 @@ packages:
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
     dev: true
+
+  /damerau-levenshtein/1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+    dev: false
 
   /dataloader/1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -1917,7 +1977,6 @@ packages:
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2187,6 +2246,31 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /eslint-config-next/12.1.0_eslint@8.11.0+typescript@4.6.2:
+    resolution: {integrity: sha512-tBhuUgoDITcdcM7xFvensi9I5WTI4dnvH4ETGRg1U8ZKpXrZsWQFdOKIDzR3RLP5HR3xXrLviaMM4c3zVoE/pA==}
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0
+      next: '>=10.2.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@next/eslint-plugin-next': 12.1.0
+      '@rushstack/eslint-patch': 1.1.0
+      '@typescript-eslint/parser': 5.12.1_eslint@8.11.0+typescript@4.6.2
+      eslint: 8.11.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.5.0_fe22d862ffeecaee86c93a006d59e41e
+      eslint-plugin-import: 2.25.4_eslint@8.11.0
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@8.11.0
+      eslint-plugin-react: 7.29.4_eslint@8.11.0
+      eslint-plugin-react-hooks: 4.3.0_eslint@8.11.0
+      typescript: 4.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /eslint-config-prettier/8.4.0_eslint@8.11.0:
     resolution: {integrity: sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==}
     hasBin: true
@@ -2206,6 +2290,24 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.0
+    dev: false
+
+  /eslint-import-resolver-typescript/2.5.0_fe22d862ffeecaee86c93a006d59e41e:
+    resolution: {integrity: sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      debug: 4.3.3
+      eslint: 8.11.0
+      eslint-plugin-import: 2.25.4_eslint@8.11.0
+      glob: 7.2.0
+      is-glob: 4.0.3
+      resolve: 1.22.0
+      tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /eslint-module-utils/2.7.3:
@@ -2307,6 +2409,27 @@ packages:
       natural-compare: 1.4.0
     dev: false
 
+  /eslint-plugin-jsx-a11y/6.5.1_eslint@8.11.0:
+    resolution: {integrity: sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      '@babel/runtime': 7.17.2
+      aria-query: 4.2.2
+      array-includes: 3.1.4
+      ast-types-flow: 0.0.7
+      axe-core: 4.4.1
+      axobject-query: 2.2.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.11.0
+      has: 1.0.3
+      jsx-ast-utils: 3.2.1
+      language-tags: 1.0.5
+      minimatch: 3.1.2
+    dev: false
+
   /eslint-plugin-node/11.1.0_eslint@8.11.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
@@ -2320,6 +2443,38 @@ packages:
       minimatch: 3.1.2
       resolve: 1.22.0
       semver: 6.3.0
+    dev: false
+
+  /eslint-plugin-react-hooks/4.3.0_eslint@8.11.0:
+    resolution: {integrity: sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.11.0
+    dev: false
+
+  /eslint-plugin-react/7.29.4_eslint@8.11.0:
+    resolution: {integrity: sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.4
+      array.prototype.flatmap: 1.2.5
+      doctrine: 2.1.0
+      eslint: 8.11.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.2.1
+      minimatch: 3.1.2
+      object.entries: 1.1.5
+      object.fromentries: 2.0.5
+      object.hasown: 1.1.0
+      object.values: 1.1.5
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.3
+      semver: 6.3.0
+      string.prototype.matchall: 4.0.6
     dev: false
 
   /eslint-plugin-regexp/1.5.1_eslint@8.11.0:
@@ -2831,7 +2986,6 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
-    dev: true
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2940,6 +3094,17 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
+  /glob/7.1.7:
+    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: false
+
   /glob/7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     dependencies:
@@ -2949,7 +3114,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
 
   /global-modules/2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -3179,7 +3343,6 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3583,6 +3746,14 @@ packages:
       graceful-fs: 4.2.9
     dev: true
 
+  /jsx-ast-utils/3.2.1:
+    resolution: {integrity: sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      array-includes: 3.1.4
+      object.assign: 4.1.2
+    dev: false
+
   /keyv/3.0.0:
     resolution: {integrity: sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==}
     dependencies:
@@ -3597,6 +3768,16 @@ packages:
   /known-css-properties/0.24.0:
     resolution: {integrity: sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==}
     dev: true
+
+  /language-subtag-registry/0.3.21:
+    resolution: {integrity: sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==}
+    dev: false
+
+  /language-tags/1.0.5:
+    resolution: {integrity: sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=}
+    dependencies:
+      language-subtag-registry: 0.3.21
+    dev: false
 
   /ldjson-stream/1.2.1:
     resolution: {integrity: sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=}
@@ -3745,7 +3926,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /lowercase-keys/1.0.0:
     resolution: {integrity: sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=}
@@ -4143,7 +4323,6 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -4163,6 +4342,31 @@ packages:
       object-keys: 1.1.1
     dev: false
 
+  /object.entries/1.1.5:
+    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
+      es-abstract: 1.19.1
+    dev: false
+
+  /object.fromentries/2.0.5:
+    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
+      es-abstract: 1.19.1
+    dev: false
+
+  /object.hasown/1.1.0:
+    resolution: {integrity: sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==}
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.19.1
+    dev: false
+
   /object.values/1.1.5:
     resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==}
     engines: {node: '>= 0.4'}
@@ -4176,7 +4380,6 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -4384,7 +4587,6 @@ packages:
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-key/2.0.1:
     resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=}
@@ -4616,6 +4818,14 @@ packages:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: true
 
+  /prop-types/15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+    dev: false
+
   /proto-list/1.2.4:
     resolution: {integrity: sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=}
     dev: true
@@ -4662,6 +4872,10 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
     dev: true
+
+  /react-is/16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: false
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -4806,7 +5020,6 @@ packages:
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
-    dev: true
 
   /regexp-ast-analysis/0.2.4:
     resolution: {integrity: sha512-8L7kOZQaKPxKKAwGuUZxTQtlO3WZ+tiXy4s6G6PKL6trbOXcZoumwC3AOHHFtI/xoSbNxt7jgLvCnP1UADLWqg==}
@@ -4825,6 +5038,14 @@ packages:
   /regexp-tree/0.1.24:
     resolution: {integrity: sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==}
     hasBin: true
+    dev: false
+
+  /regexp.prototype.flags/1.4.1:
+    resolution: {integrity: sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
     dev: false
 
   /regexpp/3.2.0:
@@ -4869,6 +5090,13 @@ packages:
       is-core-module: 2.8.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  /resolve/2.0.0-next.3:
+    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==}
+    dependencies:
+      is-core-module: 2.8.1
+      path-parse: 1.0.7
+    dev: false
 
   /responselike/1.0.2:
     resolution: {integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=}
@@ -5209,6 +5437,19 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.0.1
     dev: true
+
+  /string.prototype.matchall/4.0.6:
+    resolution: {integrity: sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.3
+      es-abstract: 1.19.1
+      get-intrinsic: 1.1.1
+      has-symbols: 1.0.2
+      internal-slot: 1.0.3
+      regexp.prototype.flags: 1.4.1
+      side-channel: 1.0.4
+    dev: false
 
   /string.prototype.trimend/1.0.4:
     resolution: {integrity: sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==}
@@ -6103,7 +6344,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
-    dev: true
 
   /write-file-atomic/4.0.1:
     resolution: {integrity: sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==}


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Add ESLint support for [React] or [Preact] UI Libraries and the [Next] framework.
Resolves feature request #31.

## Type of this Pull Request

-   ✨ Implementing a new feature
-   📝 Documentation update

---

## Resources

- [config next]
- [plugin react]
- [plugin react-hooks]
- [plugin jsx-a11y]

[react]: https://reactjs.org/
[preact]: https://preactjs.com/
[next]: https://nextjs.org/
[config next]: https://nextjs.org/docs/basic-features/eslint#eslint-config
[plugin jsx-a11y]: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
[plugin react]: https://github.com/yannickcr/eslint-plugin-react
[plugin react-hooks]: https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks

---

## TODO

-   [x] Document `README.md`
-   [x] Add [config next]
-   [x] Add [plugin react]
-   [x] Add [plugin react-hooks]
-   [x] Add [plugin jsx-a11y]
