### PR TITLE
ci(GitHub): 👷  Improve CI & CD workflow with running security tasks only when merged

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,19 +110,22 @@ jobs:
             run: pnpm syncpack list-mismatches
 
     security_codeql:
-        name: Security
+        if: github.event.pull_request.merged == true
+        name: Security / CodeQL
         # https://github.com/terminal-nerds/.github/blob/main/.github/workflows/codeql.yml
         uses: terminal-nerds/.github/.github/workflows/codeql.yml@main
 
     security_git-guardian:
-        name: Security
+        if: github.event.pull_request.merged == true
+        name: Security / Git Guardian
         # https://github.com/terminal-nerds/.github/blob/main/.github/workflows/git-guardian.yml
         uses: terminal-nerds/.github/.github/workflows/git-guardian.yml@main
         secrets:
             GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
 
     security_snyk:
-        name: Security
+        if: github.event.pull_request.merged == true
+        name: Security / Snyk
         # https://github.com/terminal-nerds/.github/blob/main/.github/workflows/snyk.yml
         uses: terminal-nerds/.github/.github/workflows/snyk.yml@main
         secrets:


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Improves GitHub workflow `Ci & CD` by adjusting security jobs to run only when Pull Request has been merged.
The point is to speed up & save resources.

---

## Type of this Pull Request

-   ⚙️ Workflow s adjustments

---

## Resources

-   [GitHub event types](https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types)
