### PR TITLE
refactor: ♻️ Move packages code to the `ESM` format

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,10 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
 	"type": "commonjs",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/eslint-config",
 	"version": "0.9.0",
 	"description": "Terminal Nerds extendable configuration for ESLint.",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -11,7 +11,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/eslint",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/eslint",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/eslint"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"type": "commonjs",
+	"type": "module",
 	"name": "@terminal-nerds/eslint-config",
 	"version": "0.9.0",
 	"description": "Terminal Nerds extendable configuration for ESLint.",
@@ -20,7 +20,10 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"main": "dist/index.js",
+	"exports": {
+		"require": "./dist/index.cjs",
+		"types": "./dist/index.d.ts"
+	},
 	"files": [
 		"/dist"
 	],
@@ -73,12 +76,12 @@
 		"eslint-plugin-unicorn": "45.0.2",
 		"eslint-plugin-yml": "1.3.0",
 		"jsonc-eslint-parser": "2.1.0",
-		"yaml-eslint-parser": "1.1.0"
+		"yaml-eslint-parser": "1.1.0",
+		"@workspace/shared": "0.0.0"
 	},
 	"devDependencies": {
 		"@terminal-nerds/typescript-config": "0.3.1",
 		"@types/eslint": "8.4.10",
-		"@workspace/shared": "0.0.0",
 		"typescript": "4.9.4"
 	}
 }

--- a/packages/eslint/source/index.ts
+++ b/packages/eslint/source/index.ts
@@ -1,6 +1,6 @@
 import { createMergedConfig } from "@workspace/shared/configuration";
 import { isContinuousIntegration } from "@workspace/shared/environment";
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import type { ESLintConfig } from "eslint-define-config";
 
 import configNext from "./configs/next.js";
@@ -31,41 +31,42 @@ import pluginTypeScript from "./plugins/typescript.js";
 import pluginUnicorn from "./plugins/unicorn.js";
 import pluginYML from "./plugins/yml.js";
 
-const mergedConfig = createMergedConfig<ESLintConfig>([
+type SimplifiedESLintConfig = Pick<ESLintConfig, keyof ESLintConfig>;
+
+const config = createMergedConfig<SimplifiedESLintConfig>([
 	// Base
 	eslint,
 
 	// Plugins
 	pluginCompat,
 	isContinuousIntegration() && pluginDiff,
-	(hasModule("@emotion/css") || hasModule("@emotion/react")) && pluginEmotion,
+	(hasPackage("@emotion/css") || hasPackage("@emotion/react")) && pluginEmotion,
 	pluginImport,
-	(hasModule("jest") || hasModule("vitest")) && pluginJest,
-	hasModule("@testing-library/jest-dom") && pluginJestDOM,
-	(hasModule("jest") || hasModule("vitest")) && pluginJestFormatting,
+	(hasPackage("jest") || hasPackage("vitest")) && pluginJest,
+	hasPackage("@testing-library/jest-dom") && pluginJestDOM,
+	(hasPackage("jest") || hasPackage("vitest")) && pluginJestFormatting,
 	pluginJSONC,
 	pluginJSONSchemaValidator,
-	(hasModule("react") || hasModule("preact")) && pluginJSXA11y,
+	(hasPackage("react") || hasPackage("preact")) && pluginJSXA11y,
 	pluginNode,
-	(hasModule("react") || hasModule("preact")) && pluginReact,
-	(hasModule("react") || hasModule("preact")) && pluginReactHooks,
+	(hasPackage("react") || hasPackage("preact")) && pluginReact,
+	(hasPackage("react") || hasPackage("preact")) && pluginReactHooks,
 	pluginRegexp,
 	pluginSimpleImportSort,
 	pluginSonarJS,
 	pluginSQL,
-	hasModule("sb") && pluginStorybook,
-	hasModule("svelte") && pluginSvelte3,
-	hasModule("@testing-library/jest-dom") && pluginTestingLibrary,
-	hasModule("tailwindcss") && pluginTailwindCSS,
-	hasModule("typescript") && pluginTypeScript,
+	hasPackage("sb") && pluginStorybook,
+	hasPackage("svelte") && pluginSvelte3,
+	hasPackage("@testing-library/jest-dom") && pluginTestingLibrary,
+	hasPackage("tailwindcss") && pluginTailwindCSS,
+	hasPackage("typescript") && pluginTypeScript,
 	pluginUnicorn,
 	pluginYML,
 
 	// Configs
-	hasModule("next") && configNext,
+	hasPackage("next") && configNext,
 	// NOTE: Must come as last!
-	hasModule("prettier") && configPrettier,
+	hasPackage("prettier") && configPrettier,
 ]);
 
-// eslint-disable-next-line unicorn/prefer-module
-module.exports = mergedConfig;
+export default config;

--- a/packages/eslint/source/plugins/import.ts
+++ b/packages/eslint/source/plugins/import.ts
@@ -1,10 +1,10 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import { defineConfig } from "eslint-define-config";
 
 const getExtendedConfigs = () => {
 	const configs = ["plugin:import/recommended"];
 
-	if (hasModule("typescript")) {
+	if (hasPackage("typescript")) {
 		configs.push("plugin:import/typescript");
 	}
 

--- a/packages/eslint/source/plugins/svelte3.ts
+++ b/packages/eslint/source/plugins/svelte3.ts
@@ -1,4 +1,4 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import { defineConfig } from "eslint-define-config";
 
 // https://github.com/sveltejs/eslint-plugin-svelte3
@@ -13,7 +13,7 @@ const config = defineConfig({
 		},
 	],
 	settings: {
-		"svelte3/typescript": hasModule("typescript"),
+		"svelte3/typescript": hasPackage("typescript"),
 	},
 });
 

--- a/packages/eslint/source/plugins/testing-library.ts
+++ b/packages/eslint/source/plugins/testing-library.ts
@@ -1,10 +1,10 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import { defineConfig } from "eslint-define-config";
 
 function getExtendedConfig() {
-	if (hasModule("react")) {
+	if (hasPackage("react")) {
 		return "plugin:testing-library/react";
-	} else if (hasModule("svelte")) {
+	} else if (hasPackage("svelte")) {
 		return "plugin:testing-library/svelte";
 	} else {
 		return "plugin:testing-library/dom";

--- a/packages/eslint/tsconfig.json
+++ b/packages/eslint/tsconfig.json
@@ -2,12 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "@terminal-nerds/typescript-config",
 	"compilerOptions": {
-		"composite": true,
 		"module": "CommonJS",
-		"outDir": "./dist",
-		"rootDir": "./source",
-		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo",
-		"types": ["eslint", "node"]
+		"moduleResolution": "NodeNext",
+		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
 	},
 	"exclude": ["dist/", "node_modules/"],
 	"include": ["source/"]

--- a/packages/eslint/tsup.config.ts
+++ b/packages/eslint/tsup.config.ts
@@ -1,12 +1,18 @@
 import { defineConfig } from "tsup";
 
+import { dependencies } from "./package.json";
+
 export default defineConfig({
+	bundle: true,
+	dts: true,
 	clean: true,
 	entry: ["source/index.ts"],
+	external: Object.keys(dependencies),
+	noExternal: ["@workspace/shared"],
 	format: ["cjs"],
 	minify: true,
-	noExternal: ["@workspace/shared"],
 	sourcemap: true,
 	splitting: false,
 	target: ["node16"],
+	treeshake: true,
 });

--- a/packages/markdownlint/package.json
+++ b/packages/markdownlint/package.json
@@ -10,7 +10,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/markdownlint",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/markdownlint",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/markdownlint"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/markdownlint/package.json
+++ b/packages/markdownlint/package.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/markdownlint-config",
 	"version": "0.4.0",
 	"description": "Terminal Nerds extendable configuration for markdownlint.",

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
+	"type": "module",
 	"name": "@terminal-nerds/prettier-config",
 	"version": "0.2.2",
 	"description": "Terminal Nerds extendable configuration for Prettier.",
@@ -19,7 +20,10 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"main": "dist/index.js",
+	"exports": {
+		"require": "./dist/index.cjs",
+		"types": "./dist/index.d.ts"
+	},
 	"files": [
 		"/dist"
 	],

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -10,7 +10,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/prettier",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/prettier",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/prettier"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/prettier-config",
 	"version": "0.2.2",
 	"description": "Terminal Nerds extendable configuration for Prettier.",

--- a/packages/prettier/source/index.ts
+++ b/packages/prettier/source/index.ts
@@ -1,5 +1,5 @@
 import { createMergedConfig } from "@workspace/shared/configuration";
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 
 import pluginSvelte from "./plugins/svelte.js";
 import prettier from "./prettier.js";
@@ -9,7 +9,7 @@ const config = createMergedConfig([
 	prettier,
 
 	// Plugins
-	hasModule("svelte") && pluginSvelte,
+	hasPackage("svelte") && pluginSvelte,
 ]);
 
 // eslint-disable-next-line unicorn/prefer-module

--- a/packages/prettier/source/index.ts
+++ b/packages/prettier/source/index.ts
@@ -1,10 +1,10 @@
 import { createMergedConfig } from "@workspace/shared/configuration";
 import { hasModule } from "@workspace/shared/module";
 
-import pluginSvelte from "./plugins/svelte";
+import pluginSvelte from "./plugins/svelte.js";
 import prettier from "./prettier.js";
 
-const mergedConfig = createMergedConfig([
+const config = createMergedConfig([
 	// Base
 	prettier,
 
@@ -13,4 +13,4 @@ const mergedConfig = createMergedConfig([
 ]);
 
 // eslint-disable-next-line unicorn/prefer-module
-module.exports = mergedConfig;
+export default config;

--- a/packages/prettier/source/plugins/svelte.ts
+++ b/packages/prettier/source/plugins/svelte.ts
@@ -1,4 +1,4 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 
 // https://github.com/sveltejs/prettier-plugin-svelte
 const config = {
@@ -20,4 +20,4 @@ const config = {
 	svelteIndentScriptAndStyle: true,
 };
 
-export default hasModule("svelte") ? config : {};
+export default hasPackage("svelte") ? config : {};

--- a/packages/prettier/source/prettier.ts
+++ b/packages/prettier/source/prettier.ts
@@ -2,7 +2,7 @@ import type { Options } from "prettier";
 
 // @see https://prettier.io/docs/en/options.html
 const config: Options = {
-	printWidth: 80,
+	printWidth: 120,
 
 	tabWidth: 4,
 	useTabs: true,

--- a/packages/prettier/tsconfig.json
+++ b/packages/prettier/tsconfig.json
@@ -4,10 +4,8 @@
 	"compilerOptions": {
 		"composite": true,
 		"module": "CommonJS",
-		"outDir": "./dist",
-		"rootDir": "./source",
-		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo",
-		"types": ["node", "prettier"]
+		"moduleResolution": "NodeNext",
+		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
 	},
 	"exclude": ["dist/", "node_modules/"],
 	"include": ["source/"]

--- a/packages/prettier/tsup.config.ts
+++ b/packages/prettier/tsup.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+	dts: true,
 	clean: true,
-	entry: ["source/index.ts"],
+	entry: ["source/**/*.ts"],
 	format: ["cjs"],
 	minify: true,
 	noExternal: ["@workspace/shared"],
 	sourcemap: true,
 	splitting: false,
 	target: ["node16"],
+	treeshake: true,
 });

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -10,7 +10,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/stylelint",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/stylelint",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/stylelint"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
+	"type": "module",
 	"name": "@terminal-nerds/stylelint-config",
 	"version": "0.6.1",
 	"description": "Terminal Nerds extendable configuration for Stylelint.",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/stylelint-config",
 	"version": "0.6.1",
 	"description": "Terminal Nerds extendable configuration for Stylelint.",

--- a/packages/stylelint/source/index.ts
+++ b/packages/stylelint/source/index.ts
@@ -1,5 +1,5 @@
 import { createMergedConfig } from "@workspace/shared/configuration";
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import type { Config } from "stylelint";
 
 import configPrettier from "./configs/prettier.js";
@@ -7,11 +7,11 @@ import configStandard from "./configs/standard.js";
 import configStandardSCSS from "./configs/standard-scss.js";
 import pluginHighPerformanceAnimations from "./plugins/high-performance-animations.js";
 import pluginNoUnsupportedBrowserFeatures from "./plugins/no-unsupported-browser-features.js";
-import pluginOrder from "./plugins/order";
+import pluginOrder from "./plugins/order/index.js";
 import pluginSCSS from "./plugins/scss.js";
 import stylelint from "./stylelint.js";
 
-const mergedConfig = createMergedConfig<Config>([
+const config = createMergedConfig<Config>([
 	// Base
 	stylelint,
 
@@ -19,14 +19,13 @@ const mergedConfig = createMergedConfig<Config>([
 	pluginHighPerformanceAnimations,
 	pluginNoUnsupportedBrowserFeatures,
 	pluginOrder,
-	hasModule("sass") && pluginSCSS,
+	hasPackage("sass") && pluginSCSS,
 
 	// Configurations
-	!hasModule("sass") && configStandard,
-	hasModule("sass") && configStandardSCSS,
+	!hasPackage("sass") && configStandard,
+	hasPackage("sass") && configStandardSCSS,
 	// NOTE: Must come as last!
-	hasModule("prettier") && configPrettier,
+	hasPackage("prettier") && configPrettier,
 ]);
 
-// eslint-disable-next-line unicorn/prefer-module
-module.exports = mergedConfig;
+export default config;

--- a/packages/stylelint/source/other/tailwind.ts
+++ b/packages/stylelint/source/other/tailwind.ts
@@ -1,13 +1,7 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 
-export const TAILWIND_AT_RULE_SELECTORS = [
-	"tailwind",
-	"apply",
-	"variants",
-	"responsive",
-	"screen",
-];
+export const TAILWIND_AT_RULE_SELECTORS = ["tailwind", "apply", "variants", "responsive", "screen"];
 
 export function extendTailwindAtRuleSelectors() {
-	return hasModule("tailwindcss") ? TAILWIND_AT_RULE_SELECTORS : [];
+	return hasPackage("tailwindcss") ? TAILWIND_AT_RULE_SELECTORS : [];
 }

--- a/packages/stylelint/source/plugins/scss.ts
+++ b/packages/stylelint/source/plugins/scss.ts
@@ -1,6 +1,6 @@
 import type { Config } from "stylelint";
 
-import { extendTailwindAtRuleSelectors } from "../other/tailwind";
+import { extendTailwindAtRuleSelectors } from "../other/tailwind.js";
 
 // https://github.com/stylelint-scss/stylelint-scss
 const config: Partial<Config> = {

--- a/packages/stylelint/source/stylelint.ts
+++ b/packages/stylelint/source/stylelint.ts
@@ -1,7 +1,7 @@
-import { hasModule } from "@workspace/shared/module";
+import { hasPackage } from "@workspace/shared/package";
 import type { Config } from "stylelint";
 
-import { extendTailwindAtRuleSelectors } from "./other/tailwind";
+import { extendTailwindAtRuleSelectors } from "./other/tailwind.js";
 
 const config: Partial<Config> = {
 	ignoreFiles: [
@@ -20,7 +20,7 @@ const config: Partial<Config> = {
 
 	rules: {
 		// https://stylelint.io/user-guide/rules/list
-		"at-rule-no-unknown": hasModule("sass")
+		"at-rule-no-unknown": hasPackage("sass")
 			? undefined
 			: [true, { ignoreAtRules: [...extendTailwindAtRuleSelectors()] }],
 
@@ -28,10 +28,7 @@ const config: Partial<Config> = {
 		"declaration-empty-line-before": undefined,
 
 		// RATIONALE: Allow CSS Modules
-		"selector-pseudo-class-no-unknown": [
-			true,
-			{ ignorePseudoClasses: ["local", "global"] },
-		],
+		"selector-pseudo-class-no-unknown": [true, { ignorePseudoClasses: ["local", "global"] }],
 
 		// RATIONALE:
 		// Longhand properties are more readable and descriptive.

--- a/packages/stylelint/tsconfig.json
+++ b/packages/stylelint/tsconfig.json
@@ -2,10 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "@terminal-nerds/typescript-config",
 	"compilerOptions": {
-		"composite": true,
 		"module": "CommonJS",
-		"outDir": "./dist",
-		"rootDir": "./source",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
 	},
 	"exclude": ["dist/", "node_modules/"],

--- a/packages/stylelint/tsup.config.ts
+++ b/packages/stylelint/tsup.config.ts
@@ -1,12 +1,18 @@
 import { defineConfig } from "tsup";
 
+import { dependencies } from "./package.json";
+
 export default defineConfig({
+	bundle: true,
+	dts: true,
 	clean: true,
 	entry: ["source/index.ts"],
+	external: Object.keys(dependencies),
+	noExternal: ["@workspace/shared"],
 	format: ["cjs"],
 	minify: true,
-	noExternal: ["@workspace/shared"],
 	sourcemap: true,
 	splitting: false,
 	target: ["node16"],
+	treeshake: true,
 });

--- a/packages/syncpack/package.json
+++ b/packages/syncpack/package.json
@@ -10,7 +10,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/syncpack",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/syncpack",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/syncpack"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/syncpack/package.json
+++ b/packages/syncpack/package.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/syncpack-config",
 	"version": "0.2.0",
 	"description": "Terminal Nerds extendable configuration for syncpack.",

--- a/packages/syncpack/package.json
+++ b/packages/syncpack/package.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/package",
+	"type": "module",
 	"name": "@terminal-nerds/syncpack-config",
 	"version": "0.2.0",
 	"description": "Terminal Nerds extendable configuration for syncpack.",
@@ -19,7 +20,10 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"main": "dist/index.js",
+	"exports": {
+		"require": "./dist/index.cjs",
+		"types": "./dist/index.d.ts"
+	},
 	"files": [
 		"/dist"
 	],

--- a/packages/syncpack/source/index.ts
+++ b/packages/syncpack/source/index.ts
@@ -8,13 +8,7 @@ const config: Partial<SyncpackConfig> = {
 	peer: true,
 	prod: true,
 	semverRange: "",
-	sortAz: [
-		"engines",
-		"files",
-		"peerDependencies",
-		"dependencies",
-		"devDependencies",
-	],
+	sortAz: ["engines", "files", "peerDependencies", "dependencies", "devDependencies"],
 	sortFirst: [
 		"$schema",
 		"private",
@@ -45,5 +39,4 @@ const config: Partial<SyncpackConfig> = {
 	workspace: true,
 };
 
-// eslint-disable-next-line unicorn/prefer-module
-module.exports = config;
+export default config;

--- a/packages/syncpack/tsconfig.json
+++ b/packages/syncpack/tsconfig.json
@@ -2,10 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "@terminal-nerds/typescript-config",
 	"compilerOptions": {
-		"composite": true,
 		"module": "CommonJS",
-		"outDir": "./dist",
-		"rootDir": "./source",
+		"moduleResolution": "NodeNext",
 		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
 	},
 	"exclude": ["dist/", "node_modules/"],

--- a/packages/syncpack/tsup.config.ts
+++ b/packages/syncpack/tsup.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+	bundle: false,
+	dts: true,
 	clean: true,
 	entry: ["source/index.ts"],
+	noExternal: ["@workspace/shared"],
 	format: ["cjs"],
 	minify: true,
-	noExternal: ["@workspace/shared"],
 	sourcemap: true,
 	splitting: false,
 	target: ["node16"],
+	treeshake: true,
 });

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -10,7 +10,11 @@
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/terminal-nerds/configs/tree/main/packages/typescript",
-	"repository": "https://github.com/terminal-nerds/configs/tree/main/packages/typescript",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/terminal-nerds/configs.git",
+		"directory": "packages/typescript"
+	},
 	"bugs": "https://github.com/terminal-nerds/configs/issues",
 	"engines": {
 		"node": ">=18"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,9 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/package",
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org/",
-		"access": "public"
-	},
 	"name": "@terminal-nerds/typescript-config",
 	"version": "0.3.1",
 	"description": "Terminal Nerds extendable configuration for TypeScript.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,12 +204,14 @@ importers:
       '@terminal-nerds/typescript-config': 0.3.1
       deepmerge-ts: 4.2.2
       read-pkg-up: 9.1.0
+      type-fest: ^3.5.0
       typescript: 4.9.4
     dependencies:
       deepmerge-ts: 4.2.2
       read-pkg-up: 9.1.0
     devDependencies:
       '@terminal-nerds/typescript-config': link:../packages/typescript
+      type-fest: 3.5.0
       typescript: 4.9.4
 
 packages:
@@ -3744,7 +3746,7 @@ packages:
     engines: {node: '>=8'}
 
   /imurmurhash/0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
   /indent-string/4.0.0:
@@ -6807,6 +6809,11 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
     dev: false
+
+  /type-fest/3.5.0:
+    resolution: {integrity: sha512-bI3zRmZC8K0tUz1HjbIOAGQwR2CoPQG68N5IF7gm0LBl8QSNXzkmaWnkWccCUL5uG9mCsp4sBwC8SBrNSISWew==}
+    engines: {node: '>=14.16'}
+    dev: true
 
   /typescript/4.9.4:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       '@emotion/eslint-plugin': 11.10.0
       '@typescript-eslint/eslint-plugin': 5.46.1_vsejax3imjndpzuqzew26kbdzm
       '@typescript-eslint/parser': 5.46.1_typescript@4.9.4
+      '@workspace/shared': link:../../shared
       eslint-config-next: 13.0.7_typescript@4.9.4
       eslint-config-prettier: 8.5.0
       eslint-define-config: 1.12.0
@@ -120,7 +121,6 @@ importers:
     devDependencies:
       '@terminal-nerds/typescript-config': link:../typescript
       '@types/eslint': 8.4.10
-      '@workspace/shared': link:../../shared
       typescript: 4.9.4
 
   packages/markdownlint:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
       '@terminal-nerds/typescript-config': 0.3.1
       deepmerge-ts: 4.2.2
       read-pkg-up: 9.1.0
-      type-fest: ^3.5.0
+      type-fest: 3.5.0
       typescript: 4.9.4
     dependencies:
       deepmerge-ts: 4.2.2

--- a/shared/.depcheckrc.json
+++ b/shared/.depcheckrc.json
@@ -1,3 +1,4 @@
 {
-	"ignores": ["@terminal-nerds/typescript-config"]
+	"ignores": ["@terminal-nerds/typescript-config", "tsup"],
+	"ignorePatterns": ["dist/", "node_modules/"]
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -50,6 +50,7 @@
 	},
 	"devDependencies": {
 		"@terminal-nerds/typescript-config": "0.3.1",
+		"type-fest": "3.5.0",
 		"typescript": "4.9.4"
 	}
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -22,6 +22,11 @@
 			"import": "./dist/module.js",
 			"require": "./dist/module.cjs",
 			"types": "./dist/module.d.ts"
+		},
+		"./package": {
+			"import": "./dist/package.js",
+			"require": "./dist/package.cjs",
+			"types": "./dist/package.d.ts"
 		}
 	},
 	"scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -10,14 +10,17 @@
 	"exports": {
 		"./configuration": {
 			"import": "./dist/configuration.js",
+			"require": "./dist/configuration.cjs",
 			"types": "./dist/configuration.d.ts"
 		},
 		"./environment": {
 			"import": "./dist/environment.js",
+			"require": "./dist/environment.cjs",
 			"types": "./dist/environment.d.ts"
 		},
 		"./module": {
 			"import": "./dist/module.js",
+			"require": "./dist/module.cjs",
 			"types": "./dist/module.d.ts"
 		}
 	},

--- a/shared/source/configuration.ts
+++ b/shared/source/configuration.ts
@@ -1,11 +1,11 @@
 import { deepmerge } from "deepmerge-ts";
 
-type Config<T extends Record<string, unknown> = Record<string, unknown>> = T;
+export type MergedConfig<T extends Record<string, unknown> = Record<string, unknown>> = T;
 
-export function createMergedConfig<
-	T extends Record<string, unknown> = Record<string, unknown>,
->(dirtyConfigsList: Array<unknown>): Config<T> {
+export function createMergedConfig<T extends Record<string, unknown> = Record<string, unknown>>(
+	dirtyConfigsList: Array<unknown>,
+): MergedConfig<T> {
 	const cleanConfigsList = dirtyConfigsList.filter(Boolean);
 
-	return deepmerge(...cleanConfigsList) as Config<T>;
+	return deepmerge(...cleanConfigsList) as MergedConfig<T>;
 }

--- a/shared/source/module.ts
+++ b/shared/source/module.ts
@@ -1,25 +1,4 @@
-import { type NormalizedPackageJson, readPackageUpSync } from "read-pkg-up";
-
-export function readPackageJSON(): NormalizedPackageJson {
-	const file = readPackageUpSync();
-
-	if (file) {
-		return file.packageJson;
-	} else {
-		throw new Error('Cannot locate "package.json" file!');
-	}
-}
-
-export function hasModule(name: string): boolean {
-	const { dependencies, devDependencies } = readPackageJSON();
-
-	return new Map(
-		Object.entries({
-			...devDependencies,
-			...dependencies,
-		}),
-	).has(name);
-}
+import { readPackageJSON } from "./package.js";
 
 export function isESModule(): boolean {
 	const { type } = readPackageJSON();

--- a/shared/source/package.ts
+++ b/shared/source/package.ts
@@ -1,0 +1,30 @@
+import { type NormalizedPackageJson, readPackageUpSync } from "read-pkg-up";
+import type { KebabCase } from "type-fest";
+
+export type PackageName<T extends string = string> = KebabCase<T>;
+
+export function readPackageJSON(): NormalizedPackageJson {
+	const file = readPackageUpSync();
+
+	if (file) {
+		return file.packageJson;
+	} else {
+		throw new Error('Cannot locate nearest "package.json" file!');
+	}
+}
+
+export type Depedencies = Partial<Record<PackageName, string>>;
+
+export function getAllDepedencies(): Depedencies {
+	const { dependencies, devDependencies, peerDependencies } = readPackageJSON();
+
+	return { ...dependencies, ...devDependencies, ...peerDependencies };
+}
+
+export function getAllPackagesNames(): Set<PackageName> {
+	return new Set(Object.keys(getAllDepedencies()));
+}
+
+export function hasPackage(name: string): boolean {
+	return getAllPackagesNames().has(name);
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -3,11 +3,7 @@
 	"extends": "@terminal-nerds/typescript-config",
 	"compilerOptions": {
 		"composite": true,
-		"module": "ESNext",
-		"outDir": "./dist",
-		"rootDir": "./source",
-		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo",
-		"types": ["node"]
+		"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo"
 	},
 	"exclude": ["dist/", "node_modules/"],
 	"include": ["source/"]

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -7,7 +7,6 @@ export default defineConfig((options) => ({
 	entry: ["source/*.ts"],
 	format: ["cjs", "esm"],
 	minify: true,
-	noExternal: ["find-up", "locate-path", "read-pkg", "read-pkg-up"],
 	outDir: "dist/",
 	shims: true,
 	skipNodeModulesBundle: true,

--- a/shared/tsup.config.ts
+++ b/shared/tsup.config.ts
@@ -1,13 +1,17 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((options) => ({
+	bundle: true,
 	clean: true,
 	dts: true,
 	entry: ["source/*.ts"],
-	format: ["esm"],
+	format: ["cjs", "esm"],
 	minify: true,
+	noExternal: ["find-up", "locate-path", "read-pkg", "read-pkg-up"],
 	outDir: "dist/",
+	shims: true,
+	skipNodeModulesBundle: true,
 	sourcemap: true,
-	splitting: true,
-	target: ["node16"],
-});
+	splitting: false,
+	treeshake: true,
+}));


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Move the following packages:

- eslint
- prettier
- syncpack
- stylelint

to the ESM format. Build outputs are still in ESM.

Added a new module in `shared` called `package`.

## Type of this Pull Request

-   ⚙️ Workflow s adjustments
-   🔧 Configurations changes
