### PR TITLE
fix(packages): 🐛 Move bundled `@workspace/shared` to `devDependencies`

### DIFF
--- a/.changeset/blue-ducks-watch.md
+++ b/.changeset/blue-ducks-watch.md
@@ -1,0 +1,7 @@
+---
+"@terminal-nerds/stylelint-config": patch
+"@terminal-nerds/prettier-config": patch
+"@terminal-nerds/eslint-config": patch
+---
+
+🐛 Move bundled `@workspace/shared` to `devDependencies`

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -50,7 +50,6 @@
 		"@emotion/eslint-plugin": "11.10.0",
 		"@typescript-eslint/eslint-plugin": "5.47.1",
 		"@typescript-eslint/parser": "5.47.1",
-		"@workspace/shared": "0.0.0",
 		"eslint-config-next": "13.1.1",
 		"eslint-config-prettier": "8.5.0",
 		"eslint-define-config": "1.12.0",
@@ -83,6 +82,7 @@
 		"@terminal-nerds/tsup-config": "workspace:*",
 		"@terminal-nerds/typescript-config": "workspace:*",
 		"@types/eslint": "8.4.10",
+		"@workspace/shared": "workspace:*",
 		"tsup": "6.5.0",
 		"typescript": "4.9.4"
 	}

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -47,7 +47,6 @@
 		"prettier": "2.8.1"
 	},
 	"dependencies": {
-		"@workspace/shared": "0.0.0",
 		"prettier-plugin-svelte": "2.9.0",
 		"prettier-plugin-tailwindcss": "0.2.1"
 	},
@@ -55,6 +54,7 @@
 		"@terminal-nerds/tsup-config": "workspace:*",
 		"@terminal-nerds/typescript-config": "workspace:*",
 		"@types/prettier": "2.7.2",
+		"@workspace/shared": "workspace:*",
 		"tsup": "6.5.0",
 		"typescript": "4.9.4"
 	}

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -44,7 +44,6 @@
 		"stylelint": "14.16.1"
 	},
 	"dependencies": {
-		"@workspace/shared": "0.0.0",
 		"stylelint-config-prettier": "9.0.4",
 		"stylelint-config-standard": "29.0.0",
 		"stylelint-config-standard-scss": "6.1.0",
@@ -56,6 +55,7 @@
 	"devDependencies": {
 		"@terminal-nerds/tsup-config": "workspace:*",
 		"@terminal-nerds/typescript-config": "workspace:*",
+		"@workspace/shared": "workspace:*",
 		"stylelint": "14.16.1",
 		"tsup": "6.5.0",
 		"typescript": "4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
       '@types/eslint': 8.4.10
       '@typescript-eslint/eslint-plugin': 5.47.1
       '@typescript-eslint/parser': 5.47.1
-      '@workspace/shared': 0.0.0
+      '@workspace/shared': workspace:*
       eslint-config-next: 13.1.1
       eslint-config-prettier: 8.5.0
       eslint-define-config: 1.12.0
@@ -104,7 +104,6 @@ importers:
       '@emotion/eslint-plugin': 11.10.0
       '@typescript-eslint/eslint-plugin': 5.47.1_lz2mbwyw4zjrdfsro6cckkmnvm
       '@typescript-eslint/parser': 5.47.1_typescript@4.9.4
-      '@workspace/shared': link:../../shared
       eslint-config-next: 13.1.1_typescript@4.9.4
       eslint-config-prettier: 8.5.0
       eslint-define-config: 1.12.0
@@ -136,6 +135,7 @@ importers:
       '@terminal-nerds/tsup-config': link:../tsup
       '@terminal-nerds/typescript-config': link:../typescript
       '@types/eslint': 8.4.10
+      '@workspace/shared': link:../../shared
       tsup: 6.5.0_typescript@4.9.4
       typescript: 4.9.4
 
@@ -154,19 +154,19 @@ importers:
       '@terminal-nerds/tsup-config': workspace:*
       '@terminal-nerds/typescript-config': workspace:*
       '@types/prettier': 2.7.2
-      '@workspace/shared': 0.0.0
+      '@workspace/shared': workspace:*
       prettier-plugin-svelte: 2.9.0
       prettier-plugin-tailwindcss: 0.2.1
       tsup: 6.5.0
       typescript: 4.9.4
     dependencies:
-      '@workspace/shared': link:../../shared
       prettier-plugin-svelte: 2.9.0
       prettier-plugin-tailwindcss: 0.2.1
     devDependencies:
       '@terminal-nerds/tsup-config': link:../tsup
       '@terminal-nerds/typescript-config': link:../typescript
       '@types/prettier': 2.7.2
+      '@workspace/shared': link:../../shared
       tsup: 6.5.0_typescript@4.9.4
       typescript: 4.9.4
 
@@ -174,7 +174,7 @@ importers:
     specifiers:
       '@terminal-nerds/tsup-config': workspace:*
       '@terminal-nerds/typescript-config': workspace:*
-      '@workspace/shared': 0.0.0
+      '@workspace/shared': workspace:*
       stylelint: 14.16.1
       stylelint-config-prettier: 9.0.4
       stylelint-config-standard: 29.0.0
@@ -186,7 +186,6 @@ importers:
       tsup: 6.5.0
       typescript: 4.9.4
     dependencies:
-      '@workspace/shared': link:../../shared
       stylelint-config-prettier: 9.0.4_stylelint@14.16.1
       stylelint-config-standard: 29.0.0_stylelint@14.16.1
       stylelint-config-standard-scss: 6.1.0_stylelint@14.16.1
@@ -197,6 +196,7 @@ importers:
     devDependencies:
       '@terminal-nerds/tsup-config': link:../tsup
       '@terminal-nerds/typescript-config': link:../typescript
+      '@workspace/shared': link:../../shared
       stylelint: 14.16.1
       tsup: 6.5.0_typescript@4.9.4
       typescript: 4.9.4


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Move bundled (and tree-shaked) `workspace/shared` to `devDependencies` in packages which use it, which causes a bug while installing them.

## Type of this Pull Request

-   🐛 Bug fix
