### PR TITLE
fix(ESLint): 🔧 Setup Jest version to stop error

### DIFF
--- a/.changeset/pretty-crews-kneel.md
+++ b/.changeset/pretty-crews-kneel.md
@@ -1,0 +1,5 @@
+---
+"@terminal-nerds/eslint-config": patch
+---
+
+🔧 Setup Jest version to `29`

--- a/packages/eslint/source/plugins/jest.ts
+++ b/packages/eslint/source/plugins/jest.ts
@@ -8,13 +8,9 @@ const config = defineConfig({
 	},
 	ignorePatterns: ["**/coverage"],
 	settings: {
-		// jest: {
-		// 	/* eslint-disable-next-line
-		// 	   unicorn/prefer-module,
-		// 	   @typescript-eslint/no-var-requires
-		// 	*/
-		// 	version: 27,
-		// },
+		jest: {
+			version: 29,
+		},
 	},
 });
 


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Setup Jest version (predefine it) to `29`, to stop error from being displayed. It only shows when using `vitest` instead as there's no separate plugin for it, yet.

## Type of this Pull Request

-   🐛 Bug fix
-   🔧 Configurations changes
