### PR TITLE
fix: 🔧 Set `peerDependencies` of  the used plugins to be optional

### DIFF
--- a/.changeset/poor-cameras-perform.md
+++ b/.changeset/poor-cameras-perform.md
@@ -1,0 +1,6 @@
+---
+"@terminal-nerds/prettier-config": patch
+"@terminal-nerds/eslint-config": patch
+---
+
+🐛 Resolve warnings about `peerDependencies` from the plugins that should be installed

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -49,6 +49,14 @@
 	"peerDependencies": {
 		"eslint": "8.32.0"
 	},
+	"peerDependenciesMeta": {
+		"svelte": {
+			"optional": true
+		},
+		"tailwindcss": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@docusaurus/eslint-plugin": "2.2.0",
 		"@emotion/eslint-plugin": "11.10.0",

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -49,6 +49,11 @@
 	"peerDependencies": {
 		"prettier": "2.8.3"
 	},
+	"peerDependenciesMeta": {
+		"svelte": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"prettier-plugin-svelte": "2.9.0",
 		"prettier-plugin-tailwindcss": "0.2.1"


### PR DESCRIPTION

# What is the purpose of this Pull Request?

Sets the `peerDependencies` of the used plugins to be optional for:

- eslint
- prettier

## Type of this Pull Request

-   🐛 Bug fix
-   Other: Resolve warning

---

## Resources

-   [`peerDependenciesMeta`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta)
