### PR TITLE
feat(Prettier): ✨ Add support for Markdown table with plugin

### DIFF
--- a/.changeset/empty-peas-walk.md
+++ b/.changeset/empty-peas-walk.md
@@ -1,0 +1,5 @@
+---
+"@terminal-nerds/prettier-config": minor
+---
+
+✨ Add support for markdown table with `prettier-plugin-sort-markdown-table`

--- a/packages/prettier/README.md
+++ b/packages/prettier/README.md
@@ -90,6 +90,8 @@ human-friendly output and performance)_.
 
 ### Plugins
 
+<!-- prettier-sort-markdown-table -->
+
 | Plugin                        | Version                                      | Loading condition(s)        |
 | ----------------------------- | -------------------------------------------- | --------------------------- |
 | [prettier-plugin-jsdoc]       | ![prettier-plugin-jsdoc version badge]       | -                           |

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -32,6 +32,7 @@
 		"@terminal-nerds/snippets-config": "0.1.0",
 		"@terminal-nerds/snippets-runtime": "0.1.0",
 		"prettier-plugin-jsdoc": "0.4.2",
+		"prettier-plugin-sort-markdown-table": "1.0.2",
 		"prettier-plugin-svelte": "2.9.0",
 		"prettier-plugin-tailwindcss": "0.2.5"
 	},

--- a/packages/prettier/source/index.ts
+++ b/packages/prettier/source/index.ts
@@ -3,6 +3,7 @@ import { createMergedConfig } from "@terminal-nerds/snippets-config";
 import { HAS_SVELTE, HAS_TAILWINDCSS } from "./checks.js";
 // eslint-disable-next-line unicorn/prevent-abbreviations
 import pluginJSDoc from "./plugins/jsdoc.js";
+import pluginSortMarkdownTable from "./plugins/sort-markdown-table.js";
 import pluginSvelte from "./plugins/svelte.js";
 import pluginTailwindCSS from "./plugins/tailwindcss.js";
 import prettier from "./prettier.js";
@@ -13,6 +14,7 @@ const config = createMergedConfig([
 
 	// Plugins
 	pluginJSDoc,
+	pluginSortMarkdownTable,
 	HAS_SVELTE && pluginSvelte,
 	HAS_TAILWINDCSS && pluginTailwindCSS,
 ]);

--- a/packages/prettier/source/plugins/jsdoc.ts
+++ b/packages/prettier/source/plugins/jsdoc.ts
@@ -1,4 +1,4 @@
-/** {@link https://github.com/hosseinmd/prettier-plugin-jsdoc} */
+/** {@link https://github.com/hosseinmd/prettier-plugin-jsdoc} Plugin JSDoc options */
 const config = {
 	plugins: ["prettier-plugin-jsdoc"],
 
@@ -17,6 +17,6 @@ const config = {
 	jsdocPreferCodeFences: true,
 	tsdoc: true,
 	jsdocLineWrappingStyle: "greedy",
-};
+} as const;
 
 export default config;

--- a/packages/prettier/source/plugins/sort-markdown-table.ts
+++ b/packages/prettier/source/plugins/sort-markdown-table.ts
@@ -1,0 +1,6 @@
+/** {@link https://github.com/SevenOutman/prettier-plugin-sort-markdown-table} Plugin sort markdown table options */
+const config = {
+	plugins: ["prettier-plugin-sort-markdown-table"],
+} as const;
+
+export default config;

--- a/packages/prettier/source/plugins/svelte.ts
+++ b/packages/prettier/source/plugins/svelte.ts
@@ -1,4 +1,4 @@
-/** @see {@link https://github.com/sveltejs/prettier-plugin-svelte} */
+/** @see {@link https://github.com/sveltejs/prettier-plugin-svelte} Plugin Svelte options */
 const config = {
 	overrides: [
 		{
@@ -16,6 +16,6 @@ const config = {
 	svelteBracketNewLine: true,
 	svelteAllowShorthand: true,
 	svelteIndentScriptAndStyle: true,
-};
+} as const;
 
 export default config;

--- a/packages/prettier/source/plugins/tailwindcss.ts
+++ b/packages/prettier/source/plugins/tailwindcss.ts
@@ -1,6 +1,6 @@
-/** @see {@link https://github.com/tailwindlabs/prettier-plugin-tailwindcss} */
+/** @see {@link https://github.com/tailwindlabs/prettier-plugin-tailwindcss} Plugin Tailwind CSS options */
 const config = {
 	plugins: ["prettier-plugin-tailwindcss"],
-};
+} as const;
 
 export default config;

--- a/packages/prettier/source/prettier.ts
+++ b/packages/prettier/source/prettier.ts
@@ -1,7 +1,7 @@
 import { END_OF_LINE, INDENT, MAX_LINE_LENGTH, QUOTES, TABS_WIDTH } from "@terminal-nerds/constants-config";
 import type { Options } from "prettier";
 
-/** @see {@link https://prettier.io/docs/en/options.html} Options */
+/** @see {@link https://prettier.io/docs/en/options.html} Prettier Options */
 const config: Options = {
 	printWidth: MAX_LINE_LENGTH,
 
@@ -21,6 +21,6 @@ const config: Options = {
 	rangeEnd: Number.POSITIVE_INFINITY,
 
 	endOfLine: END_OF_LINE,
-};
+} as const;
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,7 @@ importers:
       '@terminal-nerds/typescript-config': workspace:*
       '@types/prettier': 2.7.2
       prettier-plugin-jsdoc: 0.4.2
+      prettier-plugin-sort-markdown-table: 1.0.2
       prettier-plugin-svelte: 2.9.0
       prettier-plugin-tailwindcss: 0.2.5
       tsup: 6.6.3
@@ -222,6 +223,7 @@ importers:
       '@terminal-nerds/snippets-config': 0.1.0_typescript@4.9.5
       '@terminal-nerds/snippets-runtime': 0.1.0_typescript@4.9.5
       prettier-plugin-jsdoc: 0.4.2
+      prettier-plugin-sort-markdown-table: 1.0.2
       prettier-plugin-svelte: 2.9.0
       prettier-plugin-tailwindcss: 0.2.5_yay7g6ixlnyt6fdmnixo6d5ciu
     devDependencies:
@@ -5732,6 +5734,12 @@ packages:
       mdast-util-from-markdown: 1.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /prettier-plugin-sort-markdown-table/1.0.2:
+    resolution: {integrity: sha512-MAcnejamJM8oM7zZBW3CXurVEOWKSWLzXkyEq16kzx9bbk83PXTWif5/yB8npr0kPyRiSTa0F49cuxYDC73t8Q==}
+    peerDependencies:
+      prettier: 2.5.1
     dev: false
 
   /prettier-plugin-svelte/2.9.0:


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Add supports for markdown table with plugin - [`prettier-plugin-sort-markdown-table`].

## Type of this Pull Request

-   ✨ Implementing a new feature
-   📝 Documentation update
-   🔧 Configurations changes

---

## Resources

-   [`prettier-plugin-sort-markdown-table`]

[`prettier-plugin-sort-markdown-table`]: https://github.com/SevenOutman/prettier-plugin-sort-markdown-table
