### PR TITLE
feat(lint-staged): ✨ Allow running tests with `vitest` when available

### DIFF
--- a/.changeset/hungry-seas-give.md
+++ b/.changeset/hungry-seas-give.md
@@ -1,0 +1,5 @@
+---
+"@terminal-nerds/lint-staged-config": minor
+---
+
+✨ Allow running tests with `vitest` when available on JS/TS files

--- a/packages/lint-staged/source/checks.ts
+++ b/packages/lint-staged/source/checks.ts
@@ -8,3 +8,4 @@ export const HAS_PRETTY_QUICK = hasModule("pretty-quick");
 export const HAS_STYLELINT = hasModule("stylelint");
 export const HAS_SYNCPACK = hasModule("syncpack");
 export const HAS_TYPESCRIPT = hasModule("typescript");
+export const HAS_VITEST = hasModule("vitest");

--- a/packages/lint-staged/source/groups/tests.ts
+++ b/packages/lint-staged/source/groups/tests.ts
@@ -1,0 +1,7 @@
+import { JAVASCRIPT_EXTENSIONS, TYPESCRIPT_EXTENSIONS } from "@terminal-nerds/snippets-extension/schema";
+
+const extensions = [...JAVASCRIPT_EXTENSIONS, ...TYPESCRIPT_EXTENSIONS] as const;
+
+export const TESTS = {
+	[`*.{${extensions.join(",")}}`]: ["vitest related --run"],
+} as const;

--- a/packages/lint-staged/source/main.ts
+++ b/packages/lint-staged/source/main.ts
@@ -6,17 +6,17 @@ import {
 	HAS_STYLELINT,
 	HAS_SYNCPACK,
 	HAS_TYPESCRIPT,
+	HAS_VITEST,
 } from "./checks.js";
 import { CODE_FORMAT } from "./groups/code-format.js";
 import { ESLINT } from "./groups/eslint.js";
 import { MARKDOWN } from "./groups/markdown.js";
 import { PACKAGE_JSON } from "./groups/package-json.js";
 import { STYLESHEETS } from "./groups/stylesheets.js";
+import { TESTS } from "./groups/tests.js";
 import { TYPESCRIPT } from "./groups/typescript.js";
 
-/**
- * {@link https://github.com/okonet/lint-staged#configuration}
- */
+/** {@link https://github.com/okonet/lint-staged#configuration} */
 export const CONFIG = {
 	...(HAS_PRETTIER && CODE_FORMAT),
 	...(HAS_ESLINT && ESLINT),
@@ -24,4 +24,5 @@ export const CONFIG = {
 	...((HAS_DEPCHECK || HAS_SYNCPACK) && PACKAGE_JSON),
 	...(HAS_STYLELINT && STYLESHEETS),
 	...(HAS_TYPESCRIPT && TYPESCRIPT),
+	...(HAS_VITEST && TESTS),
 };


### PR DESCRIPTION
# What is the purpose of this Pull Request?

Adds a feature of quickly running tests on related JavaScript/TypeScript codebase file changes with `vitest`.
It has a special command `vitest related`, which tests only **[related]** files.

## Type of this Pull Request

-   ✨ Implementing a new feature
-   📝 Documentation update
-   🔧 Configurations changes

---

## Resources

-   [related]

[related]: https://vitest.dev/guide/cli.html#vitest-related
